### PR TITLE
Discover and connect to Balance Boards

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -231,7 +231,6 @@ impl WiimoteDevice {
         // (high 8 bits of X,Y,Z in the first three bytes, low 2 bits packed in the fourth byte as --XXYYZZ).
         // The four bytes at 0x001A and 0x24 store the force of gravity on those axes.
         let data = simple_io::read_16_bytes_sync_checked(self, Addressing::eeprom(0x0016, 10))?;
-        eprintln!("{:?}", data);
 
         let mut checksum = 0x55u8;
         for byte in &data[..9] {

--- a/src/device.rs
+++ b/src/device.rs
@@ -217,9 +217,11 @@ impl WiimoteDevice {
         self.motion_plus = None;
         self.extension = None;
 
-        self.calibration_data = self.read_calibration_data()?;
-        self.motion_plus = MotionPlus::detect(self)?;
         self.extension = WiimoteExtension::detect(self)?;
+        if !matches!(self.extension, Some(WiimoteExtension::BalanceBoard)) {
+            self.calibration_data = self.read_calibration_data()?;
+        }
+        self.motion_plus = MotionPlus::detect(self)?;
         Ok(())
     }
 
@@ -229,6 +231,7 @@ impl WiimoteDevice {
         // (high 8 bits of X,Y,Z in the first three bytes, low 2 bits packed in the fourth byte as --XXYYZZ).
         // The four bytes at 0x001A and 0x24 store the force of gravity on those axes.
         let data = simple_io::read_16_bytes_sync_checked(self, Addressing::eeprom(0x0016, 10))?;
+        eprintln!("{:?}", data);
 
         let mut checksum = 0x55u8;
         for byte in &data[..9] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod manager;
 mod native;
 pub mod output;
 mod result;
-mod simple_io;
+pub mod simple_io;
 
 pub const WIIMOTE_DEFAULT_REPORT_BUFFER_SIZE: usize = 32;
 

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -5,7 +5,7 @@ pub mod input;
 mod manager;
 mod native;
 pub mod output;
-mod simple_io;
+pub mod simple_io;
 
 pub use device::{AccelerometerCalibration, AccelerometerData, WiimoteDevice};
 pub use extensions::*;

--- a/src/native/common.rs
+++ b/src/native/common.rs
@@ -11,5 +11,5 @@ pub(super) const fn is_wiimote(vendor_id: u16, product_id: u16) -> bool {
 }
 
 pub(super) fn is_wiimote_device_name(name: &str) -> bool {
-    name == "Nintendo RVL-CNT-01" || name == "Nintendo RVL-CNT-01-TR"
+    name == "Nintendo RVL-CNT-01" || name == "Nintendo RVL-CNT-01-TR" || name == "Nintendo RVL-WBC-01"
 }


### PR DESCRIPTION
This PR allows `WiimoteManager` to discover Balance Boards when scanning for devices, and fixes a crash when connecting to a Balance Board caused by trying to read calibration data for an accelerometer which doesn't exist. It might be worth allowing the user to specify a filter when searching for devices so only Wiimotes/Balance Boards are returned, but this PR does not add that functionality.